### PR TITLE
Améliorer l'expérience développeur

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ npm run config
 npm start
 ```
 
-4/ Accéder à l'application sur : [localhost:7000](http://localhost:7000)
+4/ Accéder à l'application sur : [localhost:7654](http://localhost:7654)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone github.com:1024pix/pix-saml-idp.git && cd pix-saml-idp
 
 2/ Lancer le script de configuration :
 ``` shell
-npm run configure
+npm run config
 ```
 
 3/ Lancer l'application : 

--- a/config.js
+++ b/config.js
@@ -40,7 +40,7 @@ const profileMapper = SimpleProfileMapper.fromMetadata(metadata);
 module.exports = (function() {
   const config = {
     host: process.env.HOST || 'localhost',
-    port: process.env.PORT || 7000,
+    port: process.env.PORT || 7654,
     https: {
       enableHttps: process.env.HTTPS || false,
       httpsPrivateKey: process.env.HTTPS_PRIVATE_KEY,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/1024pix/pix-saml-idp/issues"
   },
   "scripts": {
-    "config": "cp sample.env .env && npm install",
+    "config": "cp sample.env .env && npm ci",
     "start": "node app.js"
   },
   "engines": {

--- a/sample.env
+++ b/sample.env
@@ -29,7 +29,7 @@
 #
 # presence: optional
 # type: Number
-# default: 7000
+# default: 7654
 # PORT=
 
 # Use https


### PR DESCRIPTION
## Problème

L'expérience développeur est améliorable.

## Solution

- Changer le port par défaut de 7000 (utilisé par macOS) à 7654
- Corriger la commande script de configuration dans le fichier README
- Utiliser `npm ci` plutôt que `npm install` dans le script de configuration