### PR TITLE
feat: add read-only mode for the env generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ npm start
 ```
 
 4/ Accéder à l'application sur : [localhost:7654](http://localhost:7654)
+
+
+## Option
+
+- La variable d'environnement `READ_ONLY_MODE=true` permet de désactiver la génération de configuration.

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ const chalk               = require('chalk'),
       samlp               = require('samlp'),
       SessionParticipants = require('samlp/lib/sessionParticipants');
 
-const { port, host, https: httpsSettings, rollSession, authentication, IDP_PATHS, UNDEFINED_VALUE, WILDCARD_ADDRESSES, CERT_OPTIONS, profile, idpOptions, metadata, sp } = require('./config')
+const { port, host, https: httpsSettings, rollSession, authentication, readOnlyMode, IDP_PATHS, UNDEFINED_VALUE, WILDCARD_ADDRESSES, CERT_OPTIONS, profile, idpOptions, metadata, sp } = require('./config')
 const { dedent } = require('./lib/utils/string-utils');
 const generateEnvironmentVariables = require('./lib/usecases/generate-environment-variables');
 
@@ -158,6 +158,7 @@ function _runServer() {
     res.render('user', {
       sp,
       user: req.user,
+      readOnlyMode: req.readOnlyMode,
       participant: req.participant,
       metadata: req.metadata,
       authnRequest: req.authnRequest,
@@ -253,6 +254,7 @@ function _runServer() {
   app.use(function(req, res, next){
     req.user = profile;
     req.metadata = metadata;
+    req.readOnlyMode = readOnlyMode;
     req.idp = { options: idpOptions };
     req.participant = getParticipant(req);
     next();

--- a/config.js
+++ b/config.js
@@ -50,6 +50,7 @@ module.exports = (function() {
     authentication: {
       secret: process.env.AUTH_SECRET,
     },
+    readOnlyMode: process.env.READ_ONLY_MODE || false,
     profile: {
       userName: 'saml.jackson@example.com',
       nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',

--- a/sample.env
+++ b/sample.env
@@ -53,8 +53,6 @@
 # default: none
 # HTTPS_CERT=
 
-
-
 # =======
 # SESSION
 # =======
@@ -79,4 +77,10 @@
 # default: none
 AUTH_SECRET=Change me!
 
+# Read-only mode to disable the env generation 
+#
+# presence: optional
+# type: Boolean
+# default: false
+READ_ONLY_MODE=false
 

--- a/views/user.hbs
+++ b/views/user.hbs
@@ -91,6 +91,13 @@
 {{#extend "scripts"}}
 <script>
 $(document).ready(function() {
+   var readOnlyMode = '{{readOnlyMode}}' === 'true';
+
+   if (readOnlyMode) {
+     $('#location').prop('disabled', true);
+     $('#btn-generate').prop('disabled', true);
+   }
+
    $("#nameIdFormat option").filter(function() {
        return $(this).text() == '{{user.nameIdFormat}}';
    }).prop('selected', true);


### PR DESCRIPTION
## 🔆 Problème

Sur certains environnements, on souhaite figer la configuration et empêcher qu'elle soit modifiée.

## ⛱️ Proposition

Ajouter une variable d'environnement `READ_ONLY_MODE` permettant de désactiver les actions de génération d'environnement.

